### PR TITLE
feat: GCP service account -sa suffix is now sa- prefix

### DIFF
--- a/bcgov/main.tf
+++ b/bcgov/main.tf
@@ -33,7 +33,7 @@ resource "google_storage_bucket" "bucket" {
 # Create GCP service accounts for each GCS bucket
 resource "google_service_account" "account" {
   for_each     = { for v in var.namespace_apps : v => "${split(",", v)[0]}-${split(",", v)[1]}" }
-  account_id   = "${each.value}-sa"
+  account_id   = "$sa-{each.value}"
   display_name = "${each.value} Service Account"
   depends_on   = [google_storage_bucket.bucket]
 }

--- a/bcgov/main.tf
+++ b/bcgov/main.tf
@@ -33,7 +33,7 @@ resource "google_storage_bucket" "bucket" {
 # Create GCP service accounts for each GCS bucket
 resource "google_service_account" "account" {
   for_each     = { for v in var.namespace_apps : v => "${split(",", v)[0]}-${split(",", v)[1]}" }
-  account_id   = "$sa-{each.value}"
+  account_id   = "sa-${each.value}"
   display_name = "${each.value} Service Account"
   depends_on   = [google_storage_bucket.bucket]
 }

--- a/tests/setup/main.tf
+++ b/tests/setup/main.tf
@@ -24,7 +24,7 @@ resource "google_storage_bucket" "bucket" {
 
 resource "google_service_account" "account" {
   count        = length(local.buckets)
-  account_id   = "${google_storage_bucket.bucket[count.index].name}-sa"
+  account_id   = "sa-${google_storage_bucket.bucket[count.index].name}"
   display_name = "${google_storage_bucket.bucket[count.index].name} Service Account"
   depends_on   = [google_storage_bucket.bucket]
 }


### PR DESCRIPTION
This ensures that the service account name starts with a letter if the bucket name starts with a number