### PR TITLE
feat: add bucket viewer role

### DIFF
--- a/bcgov/main.tf
+++ b/bcgov/main.tf
@@ -66,11 +66,18 @@ resource "google_service_account" "viewer_account" {
   depends_on   = [google_storage_bucket.bucket]
 }
 
-# # Assign Storage Viewer role for the corresponding service accounts
+resource "google_project_iam_custom_role" "viewer_role" {
+  role_id     = "casStorageViewer"
+  title       = "Storage Viewer Role"
+  description = "A role for accounts allowed to list the contents of buckets and to access files in them"
+  permissions = ["storage.buckets.get", "storage.buckets.list", "storage.objects.get", "storage.objects.list"]
+}
+
+# Assign Storage Viewer role for the corresponding service accounts
 resource "google_storage_bucket_iam_member" "viewer" {
   for_each   = { for v in var.namespace_apps : v => "${split(",", v)[0]}-${split(",", v)[1]}" }
   bucket     = each.value
-  role       = "roles/storage.objectViewer"
+  role       = google_project_iam_custom_role.viewer_role.id
   member     = "serviceAccount:${google_service_account.viewer_account[each.key].email}"
   depends_on = [google_service_account.viewer_account]
 }


### PR DESCRIPTION
The default storage viewer service account can only list the files in a bucked, not download them.