### PR TITLE
fix: remove timeout from tf-add-app-run.sh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
       - restore_cache:
           name: Restore asdf Tools Cache
           keys:
-            - tool-versions-{{ checksum ".tool-versions" }}-v3
+            - tool-versions-{{ checksum ".tool-versions" }}-v4
       - run:
           name: Install tools via asdf
           command: |
@@ -37,7 +37,7 @@ jobs:
             make install_asdf_tools
       - save_cache:
           name: Save asdf Tools Cache
-          key: tool-versions-{{ checksum ".tool-versions" }}-v3
+          key: tool-versions-{{ checksum ".tool-versions" }}-v4
           paths:
             - ~/.asdf
       - persist_to_workspace:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 terraform 0.12.31
 golang 1.14
-nodejs 12.16.1
+nodejs 14.17.6
 yarn 1.22.17
 python 3.7.0

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,6 @@ test:
 install_asdf_tools:
 	@cat .tool-versions | cut -f 1 -d ' ' | xargs -n 1 asdf plugin-add || true
 	@asdf plugin-update --all
-	@bash ~/.asdf/plugins/nodejs/bin/import-release-team-keyring
 	@#MAKELEVEL=0 is required because of https://www.postgresql.org/message-id/1118.1538056039%40sss.pgh.pa.us
 	@MAKELEVEL=0 POSTGRES_EXTRA_CONFIGURE_OPTIONS='--with-libxml' asdf install
 	@asdf reshim

--- a/tfe-scripts/tf-add-app-run.sh
+++ b/tfe-scripts/tf-add-app-run.sh
@@ -52,7 +52,6 @@ echo "run $run_id created"
 completed_statuses=(null "applied" "canceled" "discarded" "planned_and_finished")
 errored_statuses=("errored" "policy_soft_failed")
 
-count=0
 get_status() {
   status="$(get_run "$run_id" | jq -r '.data.attributes.status')"
   echo "run status - $status"
@@ -68,13 +67,6 @@ get_status() {
   if [[ "${errored_statuses[@]}" =~ "$status" ]]; then
     exit 1
   fi
-
-  if [[ "$count" -gt 50 ]]; then
-    echo "timed out"
-    exit 1
-  fi
-
-  count=$((count + 1))
 }
 
 while get_status; do sleep 5; done


### PR DESCRIPTION
Removes the timeout from tf-add-app-run.sh.
This will allow the timeout to be defined in the job that calls it rather than hardcoding a 250s timeout in the shell script.